### PR TITLE
Migrate container build to podman

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,9 @@
 name: Release Daphine
 
 on:
+  push:
+    branches:
+      - master
   release:
     types: [released]
 
@@ -11,6 +14,7 @@ env:
 
 jobs:
   build-release-container:
+    if: ${{ github.ref_type }} == 'tag'
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -23,41 +27,39 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Buildah Action
+        uses: redhat-actions/buildah-build@v2
+        id: build-image
         with:
-          buildkitd-flags: --debug
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: ${{ github.ref_name }} ${{ github.sha }}
+          containerfiles: |
+            ./Dockerfile
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: redhat-actions/podman-login@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push UI image
-        uses: docker/build-push-action@v5
+      - name: Push To ghcr.io
+        id: push-to-ghcr
+        uses: redhat-actions/push-to-registry@v2
         with:
-          context: ./
-          file: ./Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.REGISTRY }}
 
   release-chart:
+    if: ${{ github.ref_type }} == 'branch'
     permissions:
       contents: write
-      pages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Configure Git
@@ -72,8 +74,6 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
-        with:
-          charts_dir: ./charts/*
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           CR_SKIP_EXISTING: true

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -2,10 +2,12 @@ name: Test build
 
 on:
   pull_request:
-    branches: ["master"]
+    branches: ['master']
 
 env:
-  TEST_TAG: jordojordo/daphine:test
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  TEST_TAG: test
 
 jobs:
   test-build:
@@ -17,18 +19,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        # with:
-        #   buildkitd-flags: --debug
-
-      - name: Build and export to Docker
-        uses: docker/build-push-action@v5
+      - name: Buildah Action
+        uses: redhat-actions/buildah-build@v2
+        id: build-image
         with:
-          context: .
-          load: true
-          push: false
-          tags: ${{ env.TEST_TAG }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: ${{ env.TEST_TAG }} ${{ github.sha }}
+          containerfiles: |
+            ./Dockerfile

--- a/charts/daphine/Chart.yaml
+++ b/charts/daphine/Chart.yaml
@@ -3,5 +3,5 @@ name: daphine
 description: An API for streaming music and videos
 type: application
 home: 'https://github.com/jordojordo/daphine'
-version: 0.1.2
-appVersion: '0.1.2'
+version: '0.1.2-rc1'
+appVersion: '0.1.2-rc1'


### PR DESCRIPTION
Replaces the Docker build and push steps with Buildah and Podman. Also fixed the triggering action for the workflow for the chart release to work with pushes to master, which will then trigger a release and trigger the workflow build for the container.