### PR TITLE
Add ready and health routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daphine",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The API for Freedom",
   "author": "Jordon Leach",
   "license": "GPL-3.0-only",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import streamRouter from '@routes/stream';
 import musicRouter from '@routes/music';
 // import uploadRouter from "@routes/upload";
 import viewRouter from '@routes/view';
+import healthRouter from '@routes/health';
 
 import { sendErrorResponse } from '@src/utils/error';
 
@@ -29,6 +30,8 @@ app.use('/stream*', cors(CORS_OPT), streamRouter);
 app.use('/music*', cors(CORS_OPT), musicRouter);
 // app.use("/upload*", cors(CORS_OPT), uploadRouter);
 app.use('/view*', cors(CORS_OPT), viewRouter);
+app.use('/health', cors(CORS_OPT), healthRouter);
+app.use('/ready', cors(CORS_OPT), healthRouter);
 
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');

--- a/src/modules/serverEventEmitter.ts
+++ b/src/modules/serverEventEmitter.ts
@@ -1,0 +1,15 @@
+import EventEmitter from "events";
+
+class ServerEventEmitter extends EventEmitter {
+  public markServerAsReady(): void {
+    this.emit('ready', true);
+  }
+
+  public markServerAsNotReady(): void {
+    this.emit('ready', false);
+  }
+}
+
+const serverEvents = new ServerEventEmitter();
+
+export default serverEvents;

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,26 @@
+import express, { Request, Response } from 'express';
+
+import serverEvents from '@src/modules/serverEventEmitter';
+
+const router = express.Router();
+let serverReady = false;
+
+serverEvents.on('ready', (state) => {
+    serverReady = state;
+});
+
+// Liveness probe route
+router.get('/', (req: Request, res: Response) => {
+  res.sendStatus(200);
+});
+
+// Readiness probe route
+router.get('/', (req: Request, res: Response) => {
+  if ( serverReady ) {
+    res.sendStatus(200);
+  } else {
+    res.sendStatus(503);
+  }
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,7 @@
 import http from 'http';
+
 import app from './index';
+import serverEvents from '@src/modules/serverEventEmitter';
 
 const normalizePort = (val: string): number | string | void => {
 	const port = parseInt(val, 10);
@@ -12,13 +14,15 @@ const normalizePort = (val: string): number | string | void => {
 	if ( port >= 0 ) {
 		return port;
 	}
-
-
 };
 
 const onError = (error: NodeJS.ErrnoException): void => {
 	if ( error.syscall !== 'listen' ) {
 		throw error;
+	}
+
+	if ( error.syscall === 'listen' ) {
+		serverEvents.markServerAsNotReady();
 	}
 
 	const bind = typeof port === 'string' ? `Pipe ${port}` : `Port ${port}`;
@@ -38,8 +42,7 @@ const onError = (error: NodeJS.ErrnoException): void => {
 };
 
 const onListening = (): void => {
-	const addr = server.address();
-	const bind = typeof addr === 'string' ? `pipe ${ addr }` : `port ${ addr?.port }`;
+	serverEvents.markServerAsReady();
 };
 
 const port = normalizePort(process.env.PORT || '3000');


### PR DESCRIPTION
This adds the `/ready` and `/health` routes for readiness and liveness probes. The `/health` path is a simple 200 response, `/ready` will check for the status of the server which is updated when `onListening` is called within `server.ts`.

Also bumped the package to `0.2.1`