### PR TITLE
Enable pnpm manually in test build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,16 @@
 # Build stage
 FROM node:22-alpine AS build
-ENV PNPM_HOME="/pnpm"
+
+ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+ENV SHELL="/bin/sh"
+ENV ENV="/root/.profile"
+
+RUN apk add --no-cache curl ca-certificates \
+    && touch /root/.profile \
+    && curl -fsSL https://get.pnpm.io/install.sh | sh - \
+    && pnpm --version
+
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN pnpm install

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/jordojordo/daphine.git"
   },
-  "packageManager": "pnpm@9.14.4",
+  "packageManager": "pnpm@10.2.1",
   "scripts": {
     "build": "tsc && copyfiles -u 1 src/views/**/* dist",
     "start": "node ./dist/server.js",


### PR DESCRIPTION
Corepack is causing signature verification issues, this will remove the step which uses Corepack to install Pnpm and replace it with a manual step.

The Container file will now use a fixed path /root/.local/share/pnpm, which is where pnpm installs itself by default.